### PR TITLE
Add additional Compute! magazine control code handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ A control token within a string is either a {mnemonic}, {number}, {$hex}, {0xhex
 {ctrl-1}, {ctrl-2}, {ctrl-3}, {ctrl-4}, {ctrl-5}, {ctrl-6}, {ctrl-7}, {ctrl-8}, {ctrl-9}, {ctrl-0}, {ctrl-/},
 {c=1}, {c=2}, {c=3}, {c=4}, {c=5}, {c=6}, {c=7}, {c=8}
 
+In addition, additional control codes as seen in Compute! magazine are supported.  This includes repeating control codes of the format `{count code}`.  For example, `{12 right}`.  Compute! also supported a number of other aliases for the control codes shown above that are supported including:
+
+>{down}, {right}, {spaces}, {up}, {left}, {shift-space}, {rvs}, {off}
+
 ### Resource Compilation
 
 VS64 comes with an integrated resource compiler that turns media files into plain source code to be directly referenced by the code and compiled into the binary. Currently, the supported media formats are:

--- a/tools/bclib/compiler.py
+++ b/tools/bclib/compiler.py
@@ -337,6 +337,7 @@ class BasicCompiler:
         self.new_labels = []
         self.labels = {}
         self.modules = None
+        self.repeat_pattern = re.compile("(\\d+)\\s(\\w+)")
 
         if not self.options.disable_extensions:
             all_tokens = list(Constants.BASIC_TOKENS.keys()) + list(
@@ -629,6 +630,16 @@ class BasicCompiler:
                         if ofs < len(line) and line[ofs] == "}":
                             ofs += 1
                         if len(control) > 0:
+                            repeat = 1
+
+                            # Check if this is a repeating control character
+                            # seen in Cmmpute! magazine.  For example:
+                            # {23 DOWN}
+                            repeating_match = self.repeat_pattern.match(control)
+                            if repeating_match:
+                                repeat = int(repeating_match.group(1))
+                                control = repeating_match.group(2)
+
                             try:
                                 if control.startswith("$"):
                                     control_char = int(control[1:], 16)
@@ -650,7 +661,8 @@ class BasicCompiler:
                                 if not control_char:
                                     control_char = 63  # '?' if unknown control sequence
 
-                            basic_line.store_byte(control_char, f"{{{control_char}}}")
+                            for x in range(repeat):
+                                basic_line.store_byte(control_char, f"{{{control_char}}}")
 
                     else:
                         # store string characters

--- a/tools/bclib/constants.py
+++ b/tools/bclib/constants.py
@@ -318,4 +318,14 @@ class Constants:
         "c=6": 153,
         "c=7": 154,
         "c=8": 155,
-    }
+
+        # Additional Compute! codes
+        "down": 17,
+        "right": 29,
+        "spaces": 32,
+        "up": 145,
+        "left": 157,
+        "shift-space": 160,
+        "rvs": 18,
+        "off": 146,
+}


### PR DESCRIPTION
As I was trying to get my long-ago [Compute! magazine article](https://github.com/csetera/1984-compute-circus) up and running, I had been fighting to try to build a "compiler" for Commodore Basic.  However, I stumbled on to this project and realized it would be way simpler to add the additional Compute! magazine control codes that were part of their publishing.  This PR makes some minor changes to the vs64 BasicCompiler to support some additional functionality that allows the BASIC sources to be consumed without a bunch of changes.

I'm open to suggestions on these changes.  I'm not generally a Python programmer, so there may be better ways to accomplish what I'm doing.  With that said, the changes are pretty small.  I also considered whether I should add another command-line switch to enable this functionality.  However, it seemed like that code would add a lot of additional changes.