### PR TITLE
Fix broken import of KickAssemblerInfo after refactoring of debug_info.js in v2.5.7

### DIFF
--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -17,7 +17,7 @@ BIND(module);
 
 const { Logger, LogLevel } = require('utilities/logger');
 const { Utils } = require('utilities/utils');
-const { KickAssemblerInfo } = require('debugger/debug_info');
+const { KickAssemblerInfo } = require('debugger/debug_info_kick');
 
 const logger = new Logger("Builder");
 


### PR DESCRIPTION
Commit https://github.com/rolandshacks/vs64/commit/913d33994331869bf8135595ebdab5fc051c10f9 split debug_info.js into separate modules, but this import wasn't updated. If a KickAssembler compile fails, this caused the build error message parsing to fail with `TypeError: Cannot read properties of undefined (reading 'read')`.

I've tested the fix locally in v2.5.14 and can now see compile failure output.