### PR TITLE
Add opt-in BASIC alias preprocessing in compiler with integration tests, issue #114

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,70 @@ To enable the BASIC extensions, just add the compiler argument '-t' or '--tsb' t
 "args": ["--tsb"]
 ```
 
+### BASIC Variable Name Aliases
+
+In BASIC V2, variable names are effectively identified by the first two characters (plus type suffix), so different long names can collide.
+
+For example, without aliases:
+
+```
+score = 0
+screen = 1024
+```
+
+both names are treated as `SC` by the interpreter.
+
+VS64 alias preprocessing lets you use readable names prefixed with `@`, then rewrites each alias to a unique two-character BASIC variable name before compiling.
+
+Using aliases:
+
+```
+@score = 0
+@screen = 1024
+```
+
+could be rewritten to:
+
+```
+A0 = 0
+A1 = 1024
+```
+
+Aliases preserve type suffixes (`$`, `%`) and also work for function names and function parameters.
+
+Example:
+
+```
+def fn @roll(@sides%) = int(rnd(0) * @sides%) + 1
+@playerName$ = "hero"
+@score% = 0
+@diceSides% = 6
+@gravity = 9.8
+@score% = fn @roll(@diceSides%)
+```
+
+could be rewritten to:
+
+```
+def fn A0(A1%) = int(rnd(0) * A1%) + 1
+A2$ = "hero"
+A3% = 0
+A4% = 6
+A5 = 9.8
+A3% = fn A0(A4%)
+```
+
+Enable alias preprocessing via project args:
+
+```
+"args": ["--aliases"]
+```
+
+Notes:
+
+- Generated output roots avoid reserved names (for example `TI`, `ST`, `IF`, `TO`, `FN`, etc.).
+- If `--tsb` is enabled, additional TSB-sensitive roots are also avoided.
+
 ### Upper/Lower Case Character Set
 
 In order to properly use the different ROM character sets in BASIC programs, remapping of upper/lower case character codes is needed. This can be achieved in two different ways:
@@ -545,6 +609,12 @@ Optional project include paths for the compiler. The project specific include pa
 
 Optional argument list to be added to the build tool command line arguments. For more fine grained setting, use the 'assemblerFlags', 'compilerFlags' and 'linkerFlags'
 attributes.
+
+For BASIC projects, relevant args include:
+
+- `--aliases` : enable alias preprocessing for `@name` variables.
+- `--tsb` : enable Tuned Simon's BASIC extensions.
+- `--lower` : use lower-case charset mapping.
 
 > assemblerFlags
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	"scripts": {
 		"lint": "eslint .",
 		"test": "jest --runInBand --config ./jest.config.js",
+		"test:basic": "jest --runInBand --config ./jest.config.js test/basic_compiler.test.js",
 		"coverage": "jest --coverage --runInBand --config ./jest.config.js",
 		"vsix": "vsce package --no-yarn --dependencies",
 		"publish": "vsce publish",

--- a/test/basic_compiler.test.js
+++ b/test/basic_compiler.test.js
@@ -1,0 +1,267 @@
+//
+// BASIC compiler integration tests (Python bc.py)
+//
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+//-----------------------------------------------------------------------------------------------//
+// Init module and lookup path
+//-----------------------------------------------------------------------------------------------//
+
+global._sourcebase = path.resolve(__dirname, "../src");
+global.BIND = function (_module) {
+    _module.paths.push(global._sourcebase);
+};
+
+// eslint-disable-next-line
+BIND(module);
+
+//-----------------------------------------------------------------------------------------------//
+// Helpers
+//-----------------------------------------------------------------------------------------------//
+
+function findPythonExecutable() {
+    const candidates = [];
+
+    if (process.platform === "win32") {
+        candidates.push(
+            path.resolve(__dirname, "../resources/python/python.exe"),
+        );
+    }
+
+    candidates.push("python3");
+    candidates.push("python");
+
+    for (const candidate of candidates) {
+        const probe = spawnSync(candidate, ["--version"], { encoding: "utf8" });
+        if (probe.status === 0) {
+            return candidate;
+        }
+    }
+
+    return null;
+}
+
+function runBc(pyExe, args, cwd) {
+    const result = spawnSync(pyExe, args, {
+        cwd,
+        encoding: "utf8",
+    });
+
+    if (result.status !== 0) {
+        const stdout = result.stdout || "";
+        const stderr = result.stderr || "";
+        throw new Error(
+            `bc.py failed with exit code ${result.status}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        );
+    }
+
+    return result;
+}
+
+function writeFile(filePath, content) {
+    const folder = path.dirname(filePath);
+    fs.mkdirSync(folder, { recursive: true });
+    fs.writeFileSync(filePath, content, "utf8");
+}
+
+//-----------------------------------------------------------------------------------------------//
+// Tests
+//-----------------------------------------------------------------------------------------------//
+
+describe("basic_compiler", () => {
+    const pyExe = findPythonExecutable();
+
+    if (!pyExe) {
+        test("python runtime available", () => {
+            throw new Error(
+                "No Python runtime found (tried python3/python and bundled Windows python).",
+            );
+        });
+        return;
+    }
+
+    const bcScript = __context.resolve("tools/bc.py");
+    const suiteTemp = __context.resolve("temp:/basic_compiler");
+
+    beforeEach(() => {
+        fs.rmSync(suiteTemp, { recursive: true, force: true });
+        fs.mkdirSync(suiteTemp, { recursive: true });
+    });
+
+    test("compiles aliases for variables, fn names, and fn parameters", () => {
+        const projectDir = path.join(suiteTemp, "aliases_core");
+        const srcDir = path.join(projectDir, "src");
+        const buildDir = path.join(projectDir, "build");
+        const mainBas = path.join(srcDir, "main.bas");
+        const outPrg = path.join(buildDir, "out.prg");
+        const outMap = path.join(buildDir, "out.map");
+
+        writeFile(
+            mainBas,
+            [
+                "10 def fn @diceRoll(@sides)=@sides+1",
+                "20 @value = fn @diceRoll(6)",
+                "30 goto done",
+                "done:",
+                "40 print @value",
+            ].join("\n") + "\n",
+        );
+
+        runBc(
+            pyExe,
+            [
+                bcScript,
+                "--crunch",
+                "--aliases",
+                "--map",
+                outMap,
+                "-o",
+                outPrg,
+                mainBas,
+            ],
+            projectDir,
+        );
+
+        expect(fs.existsSync(outPrg)).toBeTruthy();
+        expect(fs.existsSync(outMap)).toBeTruthy();
+
+        const mapText = fs.readFileSync(outMap, "utf8");
+
+        expect(mapText.includes("@diceRoll")).toBeFalsy();
+        expect(mapText.includes("@sides")).toBeFalsy();
+        expect(mapText.includes("@value")).toBeFalsy();
+    });
+
+    test("compiles normally without aliases enabled", () => {
+        const projectDir = path.join(suiteTemp, "baseline_no_aliases");
+        const srcDir = path.join(projectDir, "src");
+        const buildDir = path.join(projectDir, "build");
+        const mainBas = path.join(srcDir, "main.bas");
+        const outPrg = path.join(buildDir, "out.prg");
+        const outMap = path.join(buildDir, "out.map");
+
+        writeFile(
+            mainBas,
+            [
+                "10 value = 7",
+                "20 if value > 0 then print \"OK\"",
+                "30 end",
+            ].join("\n") + "\n",
+        );
+
+        const result = runBc(
+            pyExe,
+            [
+                bcScript,
+                "--crunch",
+                "--map",
+                outMap,
+                "-o",
+                outPrg,
+                mainBas,
+            ],
+            projectDir,
+        );
+
+        expect(fs.existsSync(outPrg)).toBeTruthy();
+        expect(fs.existsSync(outMap)).toBeTruthy();
+        expect((result.stdout || "").includes("aliases mapped:")).toBeFalsy();
+    });
+
+    test("collects aliases across include files before preprocessing", () => {
+        const projectDir = path.join(suiteTemp, "aliases_include");
+        const srcDir = path.join(projectDir, "src");
+        const buildDir = path.join(projectDir, "build");
+        const mainBas = path.join(srcDir, "main.bas");
+        const incBas = path.join(srcDir, "inc.bas");
+        const outPrg = path.join(buildDir, "out.prg");
+        const outMap = path.join(buildDir, "out.map");
+
+        writeFile(
+            incBas,
+            ["sharedLabel:", "@sharedVar = 99", "return"].join("\n") + "\n",
+        );
+
+        writeFile(
+            mainBas,
+            [
+                '#INCLUDE "inc.bas"',
+                "10 gosub sharedLabel",
+                "20 end",
+            ].join("\n") + "\n",
+        );
+
+        const result = runBc(
+            pyExe,
+            [
+                bcScript,
+                "--crunch",
+                "--aliases",
+                "--map",
+                outMap,
+                "-o",
+                outPrg,
+                mainBas,
+            ],
+            projectDir,
+        );
+
+        expect(fs.existsSync(outPrg)).toBeTruthy();
+        expect(fs.existsSync(outMap)).toBeTruthy();
+
+        const mapText = fs.readFileSync(outMap, "utf8");
+        expect(mapText.includes("@sharedVar")).toBeFalsy();
+
+        const stdout = result.stdout || "";
+        expect(stdout.includes("aliases mapped: 1")).toBeTruthy();
+    });
+
+    test("in debug-style mode, keeps @ text in REM/strings while replacing code aliases", () => {
+        const projectDir = path.join(suiteTemp, "aliases_comment_string");
+        const srcDir = path.join(projectDir, "src");
+        const buildDir = path.join(projectDir, "build");
+        const mainBas = path.join(srcDir, "main.bas");
+        const outPrg = path.join(buildDir, "out.prg");
+        const outMap = path.join(buildDir, "out.map");
+
+        writeFile(
+            mainBas,
+            [
+                "10 rem keep @actual in rem",
+                '20 print "@actual in string"',
+                "30 @actual = 1",
+                "40 print @actual",
+                "50 end",
+            ].join("\n") + "\n",
+        );
+
+        const result = runBc(
+            pyExe,
+            [
+                bcScript,
+                "--aliases",
+                "--map",
+                outMap,
+                "-o",
+                outPrg,
+                mainBas,
+            ],
+            projectDir,
+        );
+
+        expect(fs.existsSync(outPrg)).toBeTruthy();
+        expect(fs.existsSync(outMap)).toBeTruthy();
+
+        const mapText = fs.readFileSync(outMap, "utf8");
+        expect(mapText.includes("REM keep @actual in rem")).toBeTruthy();
+        expect(mapText.includes('PRINT "@actual in string"')).toBeTruthy();
+        expect(mapText.includes("30 A0 = 1")).toBeTruthy();
+        expect(mapText.includes("40 PRINT A0")).toBeTruthy();
+
+        const stdout = result.stdout || "";
+        expect(stdout.includes("aliases mapped: 1")).toBeTruthy();
+    });
+});

--- a/tools/bc.py
+++ b/tools/bc.py
@@ -24,6 +24,7 @@ def usage():
     print("-n, --noext        : Disable BASIC extensions")
     print("-l, --lower        : Enable lower-case mode")
     print("-m, --map          : Name of source map file to be generated")
+    print("-a, --aliases      : Enable @alias preprocessing")
     print("-I, --include      : Add include directory (multiple usage possible")
     print("-o, --output       : Name of file to be generated")
     print("-u, --unpack       : Unpack a .prg into BASIC source code")
@@ -37,7 +38,7 @@ def main():
     """Main entry."""
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hvdtlumcp:I:o:", ["help", "verbose", "debug", "tsb", "lower", "unpack", "crunch", "pretty", "map=", "include=", "output="])
+        opts, args = getopt.getopt(sys.argv[1:], "hvdtlumcpa:I:o:", ["help", "verbose", "debug", "tsb", "aliases", "lower", "unpack", "crunch", "pretty", "map=", "include=", "output="])
     except getopt.GetoptError as err:
         print(err.msg)
         usage()
@@ -63,6 +64,8 @@ def main():
             options.append_include_path(arg)
         elif option in ("-t", "--tsb"):
             options.set_enable_tsb()
+        elif option in ("-a", "--aliases"):
+            options.set_enable_aliases()
         elif option in ("-v", "--verbose"):
             options.set_verbosity_level(1)
         elif option in ("-d", "--debug"):
@@ -84,6 +87,8 @@ def main():
     else:
         basic_compiler = BasicCompiler(options)
         err = basic_compiler.compile(args, output)
+        if not err and options.feature_aliases:
+            print(f"aliases mapped: {basic_compiler.alias_count}")
 
     if err:
         print(err.to_string())

--- a/tools/bc.py
+++ b/tools/bc.py
@@ -38,7 +38,7 @@ def main():
     """Main entry."""
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hvdtlumcpa:I:o:", ["help", "verbose", "debug", "tsb", "aliases", "lower", "unpack", "crunch", "pretty", "map=", "include=", "output="])
+        opts, args = getopt.getopt(sys.argv[1:], "hvdtlum:cpaI:o:", ["help", "verbose", "debug", "tsb", "aliases", "lower", "unpack", "crunch", "pretty", "map=", "include=", "output="])
     except getopt.GetoptError as err:
         print(err.msg)
         usage()

--- a/tools/bclib/common.py
+++ b/tools/bclib/common.py
@@ -151,6 +151,7 @@ class CompileOptions:
     def __init__(self):
         self.verbosity_level = 0
         self.feature_tsb = False
+        self.feature_aliases = False
         self.include_path = []
         self.map_file = None
         self.crunch = False
@@ -168,6 +169,10 @@ class CompileOptions:
     def set_enable_tsb(self):
         """Disable BASIC extensions."""
         self.feature_tsb = True
+
+    def set_enable_aliases(self):
+        """Enable BASIC @alias preprocessing."""
+        self.feature_aliases = True
 
     def set_verbosity_level(self, level):
         """Enable verbose outputs."""

--- a/tools/bclib/compiler.py
+++ b/tools/bclib/compiler.py
@@ -8,6 +8,39 @@ from typing import Optional
 from .constants import Constants
 from .common import CompileError, CompileOptions, CompileBuffer, CompileHelper
 
+BASIC_V2_RESERVED_ROOTS = {
+    "TI",
+    "ST",
+    "IF",
+    "TO",
+    "FN",
+    "ON",
+    "OR",
+    "GO",
+    "PI",
+}
+
+TSB_RESERVED_ROOTS = {
+    "AT",
+    "DO",
+    "HI",
+    "UP",
+    "ON",
+    "NO",
+    "RC",
+    "EL",
+    "TR",
+    "DI",
+    "PA",
+    "IN",
+    "TE",
+    "DE",
+    "KE",
+    "ME",
+    "ER",
+    "OU",
+}
+
 #############################################################################
 # Basic Module
 #############################################################################
@@ -353,6 +386,8 @@ class BasicCompiler:
         self.new_labels = []
         self.labels = {}
         self.modules = None
+        self.alias_map = {}
+        self.alias_count = 0
         self.repeat_pattern = re.compile("(\\d+)\\s(\\w+)")
         self.state = BasicCompilerState()
 
@@ -384,6 +419,11 @@ class BasicCompiler:
 
         # backup initial options (might be changed by preprocessor)
         initial_lower_case_settings = options.lower_case
+
+        # build alias map before preprocessing so aliased labels can be resolved
+        err = self.prepare_alias_map(inputs)
+        if err:
+            return err
 
         # run preprocessing steps
         err = self.preprocessor(inputs)
@@ -437,6 +477,286 @@ class BasicCompiler:
 
         return None
 
+    def prepare_alias_map(self, inputs: "list[str]") -> Optional[CompileError]:
+        """Collect aliases from full source/include set and build replacement map."""
+
+        self.alias_map = {}
+        self.alias_count = 0
+
+        if not self.options.feature_aliases:
+            return None
+
+        source_files = self.collect_source_files_with_includes(inputs)
+        if len(source_files) < 1:
+            return None
+
+        alias_order_keys = []
+        alias_canonical = {}
+
+        for filename in source_files:
+            try:
+                with open(filename, "r", encoding="utf-8") as src_file:
+                    lines = src_file.readlines()
+            except OSError:
+                return CompileError(filename, "could not read file")
+
+            for line in lines:
+                for token in self.tokenize_alias_tokens(line.rstrip("\n")):
+                    alias = token[1:]
+                    if not alias:
+                        continue
+
+                    alias_key = alias.lower()
+                    if alias_key in alias_canonical:
+                        continue
+
+                    alias_canonical[alias_key] = alias
+                    alias_order_keys.append(alias_key)
+
+        if len(alias_order_keys) < 1:
+            return None
+
+        pool = self.build_root_pool()
+        reserved = set(BASIC_V2_RESERVED_ROOTS)
+        if self.options.feature_tsb:
+            reserved.update(TSB_RESERVED_ROOTS)
+
+        alias_map = {}
+        for alias_key in alias_order_keys:
+            alias = alias_canonical[alias_key]
+
+            assigned_root = None
+            for root in pool:
+                if root not in reserved:
+                    assigned_root = root
+                    reserved.add(root)
+                    break
+
+            if assigned_root is None:
+                return CompileError(
+                    "",
+                    f"Could not allocate 2-character root for alias '@{alias}'. Too many aliases defined.",
+                )
+
+            suffix = ""
+            if alias.endswith("$") or alias.endswith("%"):
+                suffix = alias[-1]
+
+            alias_map[alias_key] = assigned_root + suffix
+
+        self.alias_map = alias_map
+        self.alias_count = len(alias_order_keys)
+
+        return None
+
+    def collect_source_files_with_includes(self, entry_files: "list[str]") -> "list[str]":
+        """Collect full source set by recursively following #include directives."""
+
+        queue = []
+        visited = set()
+        ordered_files = []
+
+        for filename in entry_files:
+            queue.append(os.path.abspath(filename))
+
+        while len(queue) > 0:
+            current = queue.pop(0)
+            if current in visited:
+                continue
+
+            visited.add(current)
+            if not os.path.exists(current):
+                continue
+
+            ordered_files.append(current)
+
+            try:
+                with open(current, "r", encoding="utf-8") as src_file:
+                    lines = src_file.readlines()
+            except OSError:
+                continue
+
+            parent_dir = os.path.dirname(current)
+            for line in lines:
+                include_path = self.extract_include_path(line)
+                if not include_path:
+                    continue
+
+                resolved = self.lookup_file(include_path, parent_dir)
+                if not resolved:
+                    continue
+
+                if resolved not in visited:
+                    queue.append(resolved)
+
+        return ordered_files
+
+    def extract_include_path(self, line: str) -> Optional[str]:
+        """Extract include path from #include lines."""
+
+        trimmed = line.strip()
+        result = re.match(r'^#include\s+["\']([^"\']+)["\']', trimmed, re.IGNORECASE)
+        if not result:
+            return None
+
+        return result.group(1)
+
+    def is_letter(self, c: str) -> bool:
+        return bool(re.match(r"[a-zA-Z]", c))
+
+    def is_alphanumeric(self, c: str) -> bool:
+        return bool(re.match(r"[a-zA-Z0-9]", c))
+
+    def read_alias_token(self, line: str, start: int) -> tuple[str, int]:
+        """Read identifier token with optional @ prefix and type suffix."""
+
+        i = start
+        n = len(line)
+        text = ""
+
+        if i < n and line[i] == "@":
+            text += "@"
+            i += 1
+
+        if i >= n:
+            return text, i
+
+        text += line[i]
+        i += 1
+
+        while i < n and self.is_alphanumeric(line[i]):
+            text += line[i]
+            i += 1
+
+        if i < n and (line[i] == "$" or line[i] == "%"):
+            text += line[i]
+            i += 1
+
+        return text, i
+
+    def tokenize_alias_tokens(self, line: str) -> "list[str]":
+        """Extract @alias tokens outside strings/comments."""
+
+        trimmed = line.strip()
+        if trimmed.startswith("#") or trimmed.startswith(";"):
+            return []
+
+        tokens = []
+        i = 0
+        n = len(line)
+        in_string = False
+
+        while i < n:
+            ch = line[i]
+
+            if ch == '"':
+                in_string = not in_string
+                i += 1
+                continue
+
+            if not in_string:
+                if ch == "'":
+                    break
+
+                if ch == "@" and i + 1 < n and self.is_letter(line[i + 1]):
+                    token, next_i = self.read_alias_token(line, i)
+                    tokens.append(token)
+                    i = next_i
+                    continue
+
+                if self.is_letter(ch):
+                    token, next_i = self.read_alias_token(line, i)
+                    if token.upper() == "REM":
+                        break
+                    i = next_i
+                    continue
+
+            i += 1
+
+        return tokens
+
+    def replace_aliases_in_line(self, line: str) -> str:
+        """Replace @alias identifiers in a single line."""
+
+        if self.alias_count < 1:
+            return line
+
+        trimmed = line.strip()
+        if trimmed.startswith("#") or trimmed.startswith(";"):
+            return line
+
+        out = []
+        i = 0
+        n = len(line)
+        in_string = False
+
+        while i < n:
+            ch = line[i]
+
+            if ch == '"':
+                in_string = not in_string
+                out.append(ch)
+                i += 1
+                continue
+
+            if not in_string:
+                if ch == "'":
+                    out.append(line[i:])
+                    break
+
+                if ch == "@" and i + 1 < n and self.is_letter(line[i + 1]):
+                    token, next_i = self.read_alias_token(line, i)
+                    alias_name = token[1:]
+                    alias_key = alias_name.lower()
+                    if alias_key in self.alias_map:
+                        out.append(self.alias_map[alias_key])
+                    else:
+                        out.append(token)
+
+                    i = next_i
+                    continue
+
+                if self.is_letter(ch):
+                    token, next_i = self.read_alias_token(line, i)
+                    if token.upper() == "REM":
+                        out.append(line[i:])
+                        break
+                    out.append(token)
+                    i = next_i
+                    continue
+
+            out.append(ch)
+            i += 1
+
+        return "".join(out)
+
+    def build_root_pool(self) -> "list[str]":
+        """Build available 2-character roots from A0..ZZ."""
+
+        start = int("A0", 36)
+        end = int("ZZ", 36)
+        pool = []
+
+        for number in range(start, end + 1):
+            pool.append(self.to_base36(number))
+
+        return pool
+
+    def to_base36(self, value: int) -> str:
+        """Convert integer to upper-case base36 string."""
+
+        if value == 0:
+            return "0"
+
+        digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        out = ""
+        n = value
+        while n > 0:
+            n, rem = divmod(n, 36)
+            out = digits[rem] + out
+
+        return out
+
     def preprocessor(self, inputs: "list[str]") -> Optional[CompileError]:
         """Preprocess files."""
 
@@ -466,7 +786,7 @@ class BasicCompiler:
 
         line_index = -1
         for raw_line in data:
-            line = raw_line.strip()
+            line = self.replace_aliases_in_line(raw_line.rstrip("\n")).strip()
             line_index += 1
 
             if len(line) < 1:
@@ -580,7 +900,7 @@ class BasicCompiler:
 
         line_index = -1
         for raw_line in data:
-            line = raw_line.strip()
+            line = self.replace_aliases_in_line(raw_line.rstrip("\n")).strip()
             line_index += 1
 
             if len(line) < 1:


### PR DESCRIPTION
### Summary
This PR moves BASIC alias preprocessing into the Python compiler flow and keeps it strictly opt-in. This is in relation to issue #114 

When enabled, aliases prefixed with `@` are rewritten to valid two-character BASIC identifiers before preprocessing and compilation. This avoids BASIC V2 name collisions while preserving existing behavior for projects that do not enable aliases.

### Scope
Included: alias feature work, CLI wiring, reserved-root handling, and tests.

### What Changed

1. Added an opt-in alias feature flag in compiler options.
- `tools/bclib/common.py`

2. Added CLI support for aliases.
- Added flags: --aliases and -a.
- Updated short-option parsing to support alias flag behavior alongside existing CLI options.
- Alias summary output on successful compile when aliases are enabled.
- tools/bc.py

3. Implemented compiler-internal alias mapping and replacement.
- Builds alias map before preprocessing
- Collects aliases across entry files and includes
- Replaces aliases only in code contexts (not inside strings/comments)
- Preserves type suffixes (`$`, `%`)
- Avoids reserved output roots (BASIC V2 roots, plus TSB-sensitive roots when TSB mode is enabled)
- `tools/bclib/compiler.py`

4. Aligned alias include discovery with compiler include behavior.
- Alias pre-scan include extraction is case-insensitive, matching compiler include handling
- `tools/bclib/compiler.py`

5. Added focused integration tests (no new dependencies).
- `test/basic_compiler.test.js`
- Added test script in `package.json`: `test:basic`

### Tests Added

1. Aliases for variables, function names, and function parameters compile correctly.
2. Baseline compile without aliases enabled (opt-in behavior).
3. Aliases are collected from included files before preprocessing, including uppercase include directive form.
4. In debug-style mode (no crunch), `@` text is preserved in `REM` and string literals while code aliases are replaced.

### Validation Run
- `npm run test:basic`
- Result: 1 suite passed, 4 tests passed

### Documentation
- README updated with alias usage and examples
- `README.md`